### PR TITLE
Refined offset handling in versions around 23h2 - 24h2

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,9 @@
+# Contributors
+> `memflow-win32` includes contributions from the following individuals
+
+- ko1N
+- h33p
+- ntdelta
+- xmr-slack
+- youduda
+- ConnorBP

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "memflow-win32"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "log",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "memflow-win32-defs"
-version = "0.2.1"
+version = "0.2.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "memflow-win32-defs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "arrayvec",
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +156,12 @@ dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "as_derive_utils"
@@ -256,6 +273,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +309,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -328,6 +380,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +412,15 @@ name = "core_extensions_proc_macros"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f3b219d28b6e3b4ac87bc1fc522e0803ab22e055da177bff0068c4150c61a6"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -371,6 +445,17 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -514,6 +599,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +645,12 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
@@ -611,6 +712,15 @@ dependencies = [
  "number_prefix",
  "portable-atomic",
  "unicode-width",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -780,6 +890,7 @@ dependencies = [
  "log",
  "memflow",
  "memflow-win32-defs",
+ "muddy",
  "no-std-compat",
  "pelite 0.10.0",
  "rand",
@@ -829,6 +940,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "muddy"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527591991935a691d25c12b6789713c83878b40164f993315f82095ce64cd0a6"
+dependencies = [
+ "aead",
+ "arrayvec",
+ "chacha20poly1305",
+ "const-hex",
+ "muddy_macros",
+]
+
+[[package]]
+name = "muddy_macros"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4013b5ee487b1cd042f96525d875001a4ce73711c99604e36c9a91691b279870"
+dependencies = [
+ "chacha20poly1305",
+ "proc-macro2",
+ "quote",
+ "rand",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +1009,12 @@ checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "option-ext"
@@ -963,6 +1106,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1161,22 @@ name = "progress-streams"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e965d96c8162c607b0cd8d66047ad3c9fd35273c134d994327882c6e47f986a7"
+
+[[package]]
+name = "proptest"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+dependencies = [
+ "bitflags 2.6.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
 
 [[package]]
 name = "quote"
@@ -1493,6 +1663,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1700,16 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/memflow-win32-defs/Cargo.toml
+++ b/memflow-win32-defs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memflow-win32-defs"
-version = "0.2.1"
+version = "0.2.0"
 authors = ["ko1N <ko1N1337@gmail.com>", "Aurimas Blažulionis <0x60@pm.me>"]
 edition = "2018"
 description = "static offset templates for "

--- a/memflow-win32-defs/Cargo.toml
+++ b/memflow-win32-defs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memflow-win32-defs"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["ko1N <ko1N1337@gmail.com>", "Aurimas Blažulionis <0x60@pm.me>"]
 edition = "2018"
 description = "static offset templates for "

--- a/memflow-win32/Cargo.toml
+++ b/memflow-win32/Cargo.toml
@@ -28,6 +28,7 @@ widestring = { version = "1.1", default-features = false, features = ["alloc"] }
 no-std-compat = { version = "0.4", features = ["alloc"] }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 memflow-win32-defs = { version = "0.2", path = "../memflow-win32-defs", default-features = false }
+muddy = "0.3.2"
 
 # will be replaced by our own signature scanner
 regex = { version = "1.11", optional = true }

--- a/memflow-win32/Cargo.toml
+++ b/memflow-win32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memflow-win32"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["ko1N <ko1N1337@gmail.com>", "Aurimas Blažulionis <0x60@pm.me>"]
 edition = "2021"
 rust-version = "1.65"

--- a/memflow-win32/Cargo.toml
+++ b/memflow-win32/Cargo.toml
@@ -47,7 +47,7 @@ memflow = { version = "0.2", default-features = false }
 memflow-win32-defs = { version = "0.2", path = "../memflow-win32-defs", features = ["symstore"] }
 
 [features]
-default = ["std", "serde_derive", "embed_offsets", "symstore", "download_progress", "regex", "memflow/default"]
+default = ["std", "serde_derive", "embed_offsets", "symstore", "download_progress", "regex", "memflow/default", "plugins"]
 std = ["no-std-compat/std", "memflow/std", "pelite/std"]
 plugins = ["memflow/plugins"]
 embed_offsets = ["serde", "memflow/serde_derive", "memflow-win32-defs/serde"]

--- a/memflow-win32/examples/keyboard_listen.rs
+++ b/memflow-win32/examples/keyboard_listen.rs
@@ -13,7 +13,7 @@ cargo run --release --example keyboard_listen -- -vv -c kvm
 ```
 */
 use clap::*;
-use log::{info, Level};
+use log::Level;
 
 use memflow::prelude::v1::*;
 use memflow_win32::prelude::v1::*;

--- a/memflow-win32/examples/keyboard_listen.rs
+++ b/memflow-win32/examples/keyboard_listen.rs
@@ -1,0 +1,93 @@
+/*!
+This example shows how to use a dynamically loaded connector in conjunction
+with memflow-win32. This example uses the `Inventory` feature of memflow
+but hard-wires the connector instance into the memflow-win32 OS layer.
+
+The example is an adaption of the memflow core process list example:
+https://github.com/memflow/memflow/blob/next/memflow/examples/process_list.rs
+
+# Usage:
+```bash
+cargo run --release --example process_list -- -vv -c kvm
+```
+*/
+use clap::*;
+use log::{info, Level};
+
+use memflow::prelude::v1::*;
+use memflow_win32::prelude::v1::*;
+
+pub fn main() -> Result<()> {
+    let matches = parse_args();
+    let chain = extract_args(&matches)?;
+
+    // create inventory + connector
+    let inventory = Inventory::scan();
+    let connector = inventory.builder().connector_chain(chain).build()?;
+
+    let os = Win32Kernel::builder(connector)
+        .build_default_caches()
+        .build()
+        .unwrap();
+
+    let mut kb = os.into_keyboard()?;
+
+    // listen for keyboard events until escape is pressed
+    while !kb.is_down(vkey::VK_ESCAPE.into()) {
+        if kb.is_down(vkey::VK_LSHIFT.into())
+        {
+            info!("Left Shift is down");
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_args() -> ArgMatches {
+    Command::new("process_list example")
+        .version(crate_version!())
+        .author(crate_authors!())
+        .arg(Arg::new("verbose").short('v').action(ArgAction::Count))
+        .arg(
+            Arg::new("connector")
+                .short('c')
+                .action(ArgAction::Append)
+                .required(true),
+        )
+        .arg(Arg::new("os").short('o').action(ArgAction::Append))
+        .get_matches()
+}
+
+fn extract_args(matches: &ArgMatches) -> Result<ConnectorChain<'_>> {
+    let log_level = match matches.get_count("verbose") {
+        0 => Level::Error,
+        1 => Level::Warn,
+        2 => Level::Info,
+        3 => Level::Debug,
+        4 => Level::Trace,
+        _ => Level::Trace,
+    };
+    simplelog::TermLogger::init(
+        log_level.to_level_filter(),
+        simplelog::Config::default(),
+        simplelog::TerminalMode::Stdout,
+        simplelog::ColorChoice::Auto,
+    )
+    .unwrap();
+
+    let conn_iter = matches
+        .indices_of("connector")
+        .zip(matches.get_many::<String>("connector"))
+        .map(|(a, b)| a.zip(b.map(String::as_str)))
+        .into_iter()
+        .flatten();
+
+    let os_iter = matches
+        .indices_of("os")
+        .zip(matches.get_many::<String>("os"))
+        .map(|(a, b)| a.zip(b.map(String::as_str)))
+        .into_iter()
+        .flatten();
+
+    ConnectorChain::new(conn_iter, os_iter)
+}

--- a/memflow-win32/examples/keyboard_listen.rs
+++ b/memflow-win32/examples/keyboard_listen.rs
@@ -16,7 +16,7 @@ use clap::*;
 use log::Level;
 
 use memflow::prelude::v1::*;
-use memflow_win32::prelude::v1::*;
+use memflow_win32::{prelude::v1::*, win32::vkey::*};
 
 pub fn main() -> Result<()> {
     let matches = parse_args();
@@ -36,13 +36,34 @@ pub fn main() -> Result<()> {
         .unwrap();
 
     let mut kb = os.into_keyboard()?;
-    println!("Running keyboard listener...\n...............................");
+    println!("Running keyboard example...\n...............................");
+
+    println!("Checking all keys...");
+
+    for k in vkey_range(VK_LBUTTON, VK_NONE) {
+        let down = if kb.is_down(k.into()) { "down" } else { "up" };
+        println!("Key {k} is {down}");
+    }
+
+    println!("Starting keyboard listener...");
+
     println!("Press ESC to exit");
-    println!("Press LSHIFT to see if it is down");
+    println!("Press any key to see if it reads out here");
     // listen for keyboard events until escape is pressed
-    while !kb.is_down(vkey::VK_ESCAPE.into()) {
-        if kb.is_down(vkey::VK_LSHIFT.into()) {
-            println!("Left Shift is down");
+    'listener: loop {
+        for k in vkey_range(VK_LBUTTON, VK_NONE) {
+            // check escape first each time for responsiveness
+            if kb.is_down(vkey::VK_ESCAPE.into()) {
+                println!("Escape pressed, exiting...");
+                break 'listener;
+            }
+            if kb.is_down(k.into()) {
+                println!("Key {k} is down");
+                // sleep for a bit to avoid spamming
+                // note: this is for example purposes only, in a real application
+                // you would probably not want to block the thread like this
+                std::thread::sleep(std::time::Duration::from_millis(200));
+            }
         }
     }
 

--- a/memflow-win32/examples/keyboard_listen.rs
+++ b/memflow-win32/examples/keyboard_listen.rs
@@ -20,11 +20,15 @@ use memflow_win32::prelude::v1::*;
 
 pub fn main() -> Result<()> {
     let matches = parse_args();
-    let (chain,conn_args) = extract_args(&matches)?;
+    let (chain, conn_args) = extract_args(&matches)?;
 
     // create inventory + connector
     let inventory = Inventory::scan();
-    let connector = inventory.builder().connector_chain(chain).args(conn_args.parse()?).build()?;
+    let connector = inventory
+        .builder()
+        .connector_chain(chain)
+        .args(conn_args.parse()?)
+        .build()?;
 
     let os = Win32Kernel::builder(connector)
         .build_default_caches()
@@ -37,8 +41,7 @@ pub fn main() -> Result<()> {
     println!("Press LSHIFT to see if it is down");
     // listen for keyboard events until escape is pressed
     while !kb.is_down(vkey::VK_ESCAPE.into()) {
-        if kb.is_down(vkey::VK_LSHIFT.into())
-        {
+        if kb.is_down(vkey::VK_LSHIFT.into()) {
             println!("Left Shift is down");
         }
     }
@@ -67,7 +70,7 @@ fn parse_args() -> ArgMatches {
         .get_matches()
 }
 
-fn extract_args(matches: &ArgMatches) -> Result<(ConnectorChain<'_>,String)> {
+fn extract_args(matches: &ArgMatches) -> Result<(ConnectorChain<'_>, String)> {
     let log_level = match matches.get_count("verbose") {
         0 => Level::Error,
         1 => Level::Warn,
@@ -98,7 +101,10 @@ fn extract_args(matches: &ArgMatches) -> Result<(ConnectorChain<'_>,String)> {
         .into_iter()
         .flatten();
 
-    let conn_args = matches.get_one::<String>("connector_args").map(String::to_owned).unwrap_or(String::new());
+    let conn_args = matches
+        .get_one::<String>("connector_args")
+        .map(String::to_owned)
+        .unwrap_or(String::new());
 
     Ok((ConnectorChain::new(conn_iter, os_iter)?, conn_args))
 }

--- a/memflow-win32/examples/open_process.rs
+++ b/memflow-win32/examples/open_process.rs
@@ -13,6 +13,7 @@ cargo run --release --example open_process -- -vv -c kvm -p "explorer.exe"
 */
 use clap::*;
 use log::{info, Level};
+use muddy::muddy;
 
 use memflow::prelude::v1::*;
 use memflow_win32::prelude::v1::*;
@@ -20,7 +21,7 @@ use memflow_win32::prelude::v1::*;
 pub fn main() -> Result<()> {
     let matches = parse_args();
     let (chain, process_name) = extract_args(&matches)?;
-    let process_name = process_name.unwrap_or("explorer.exe");
+    let process_name = process_name.unwrap_or(muddy!("explorer.exe"));
 
     // create inventory + connector
     let inventory = Inventory::scan();

--- a/memflow-win32/src/ida_signatures.rs
+++ b/memflow-win32/src/ida_signatures.rs
@@ -2,7 +2,7 @@
 /// Made by [@ConnorBP] :)
 /// Main benefit of this is that you can directly use your ida signatures,
 /// while not needing to decode them at runtime or manually beforehand.
-/// 
+///
 /// Example Usage:
 /// ```
 /// use regex::Regex;

--- a/memflow-win32/src/ida_signatures.rs
+++ b/memflow-win32/src/ida_signatures.rs
@@ -1,0 +1,34 @@
+use regex::Regex;
+
+/// Generates a regex string from an ida-like hex string.
+/// Made by [@ConnorBP] :)
+/// Main benefit of this is that you can directly use your ida signatures,
+/// while not needing to decode them at runtime or manually beforehand.
+/// 
+/// Example Usage:
+/// ```
+/// const REGEX_PATTERN: &str = ida_regex![4C 8B ? ? ? ? 3C 9F];
+/// let re = Regex::new(REGEX_PATTERN).unwrap();
+/// assert_eq!(REGEX_PATTERN, "(?-u)\\x4C\\x8B(?s:.){4}\\x3C\\x9F");
+/// ```
+#[macro_export]
+macro_rules! ida_regex {
+    ( $($token:tt)+ ) => {
+        concat!(
+            "(?-u)", // Search with unicode code-points disabled. \\x4C is actually equal to the hex byte 0x4C
+            $(
+                $crate::ida_regex_part!($token)
+            ),*
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! ida_regex_part {
+    (?) => {
+        "(?s:.)"
+    };
+    ($hex:tt) => {
+        concat!("\\x", stringify!($hex))
+    };
+}

--- a/memflow-win32/src/ida_signatures.rs
+++ b/memflow-win32/src/ida_signatures.rs
@@ -1,5 +1,4 @@
 /// Generates a regex string from an ida-like hex string.
-/// Made by [@ConnorBP] :)
 /// Main benefit of this is that you can directly use your ida signatures,
 /// while not needing to decode them at runtime or manually beforehand.
 ///

--- a/memflow-win32/src/ida_signatures.rs
+++ b/memflow-win32/src/ida_signatures.rs
@@ -1,5 +1,3 @@
-use regex::Regex;
-
 /// Generates a regex string from an ida-like hex string.
 /// Made by [@ConnorBP] :)
 /// Main benefit of this is that you can directly use your ida signatures,
@@ -7,6 +5,8 @@ use regex::Regex;
 /// 
 /// Example Usage:
 /// ```
+/// use regex::Regex;
+/// use memflow_win32::ida_regex;
 /// const REGEX_PATTERN: &str = ida_regex![4C 8B ? ? ? ? 3C 9F];
 /// let re = Regex::new(REGEX_PATTERN).unwrap();
 /// assert_eq!(REGEX_PATTERN, "(?-u)\\x4C\\x8B(?s:.){4}\\x3C\\x9F");

--- a/memflow-win32/src/kernel/ntos/x86.rs
+++ b/memflow-win32/src/kernel/ntos/x86.rs
@@ -46,7 +46,7 @@ pub fn find<T: MemoryView>(virt_mem: &mut T, _start_block: &StartBlock) -> Resul
             let image_base = Address::from(base_addr + addr);
             if let Ok(name) = pehelper::try_get_pe_name(virt_mem, image_base) {
                 if name == muddy!("ntoskrnl.exe") {
-                    info!("{}",muddy!("ntoskrnl found"));
+                    info!("{}", muddy!("ntoskrnl found"));
                     // TODO: unify pe name + size
                     if let Ok(size_of_image) = pehelper::try_get_pe_size(virt_mem, image_base) {
                         return Ok((image_base, size_of_image));
@@ -56,6 +56,9 @@ pub fn find<T: MemoryView>(virt_mem: &mut T, _start_block: &StartBlock) -> Resul
         }
     }
 
-    Err(Error(ErrorOrigin::OsLayer, ErrorKind::ProcessNotFound)
-        .log_trace(muddy!("find_x86(): unable to locate ntoskrnl.exe in high mem")))
+    Err(
+        Error(ErrorOrigin::OsLayer, ErrorKind::ProcessNotFound).log_trace(muddy!(
+            "find_x86(): unable to locate ntoskrnl.exe in high mem"
+        )),
+    )
 }

--- a/memflow-win32/src/kernel/ntos/x86.rs
+++ b/memflow-win32/src/kernel/ntos/x86.rs
@@ -10,6 +10,8 @@ use memflow::types::{size, umem, Address};
 
 use log::{debug, info};
 
+use muddy::muddy;
+
 use pelite::image::IMAGE_DOS_HEADER;
 
 const SIZE_256MB: usize = size::mb(256);
@@ -43,8 +45,8 @@ pub fn find<T: MemoryView>(virt_mem: &mut T, _start_block: &StartBlock) -> Resul
 
             let image_base = Address::from(base_addr + addr);
             if let Ok(name) = pehelper::try_get_pe_name(virt_mem, image_base) {
-                if name == "ntoskrnl.exe" {
-                    info!("ntoskrnl found");
+                if name == muddy!("ntoskrnl.exe") {
+                    info!("{}",muddy!("ntoskrnl found"));
                     // TODO: unify pe name + size
                     if let Ok(size_of_image) = pehelper::try_get_pe_size(virt_mem, image_base) {
                         return Ok((image_base, size_of_image));
@@ -55,5 +57,5 @@ pub fn find<T: MemoryView>(virt_mem: &mut T, _start_block: &StartBlock) -> Resul
     }
 
     Err(Error(ErrorOrigin::OsLayer, ErrorKind::ProcessNotFound)
-        .log_trace("find_x86(): unable to locate ntoskrnl.exe in high mem"))
+        .log_trace(muddy!("find_x86(): unable to locate ntoskrnl.exe in high mem")))
 }

--- a/memflow-win32/src/kernel/sysproc.rs
+++ b/memflow-win32/src/kernel/sysproc.rs
@@ -53,8 +53,11 @@ pub fn find_exported<T: MemoryView>(
     {
         Export::Symbol(s) => kernel_base + *s as umem,
         Export::Forward(_) => {
-            return Err(Error(ErrorOrigin::OsLayer, ErrorKind::ExportNotFound)
-                .log_info(muddy!("PsInitialSystemProcess found but it was a forwarded export")))
+            return Err(
+                Error(ErrorOrigin::OsLayer, ErrorKind::ExportNotFound).log_info(muddy!(
+                    "PsInitialSystemProcess found but it was a forwarded export"
+                )),
+            )
         }
     };
     info!("{tgt} found at 0x{:x}", sys_proc);

--- a/memflow-win32/src/lib.rs
+++ b/memflow-win32/src/lib.rs
@@ -12,6 +12,9 @@ pub mod offsets;
 
 pub mod win32;
 
+#[cfg(feature = "regex")]
+pub mod ida_signatures;
+
 pub mod prelude {
     pub mod v1 {
         pub use crate::kernel::*;

--- a/memflow-win32/src/win32.rs
+++ b/memflow-win32/src/win32.rs
@@ -7,11 +7,11 @@ pub use kernel_builder::Win32KernelBuilder;
 pub use kernel_info::Win32KernelInfo;
 
 pub mod keyboard;
-pub mod vkey;
 pub mod module;
 pub mod process;
 pub mod unicode_string;
 pub mod vat;
+pub mod vkey;
 
 pub use keyboard::*;
 pub use module::*;

--- a/memflow-win32/src/win32.rs
+++ b/memflow-win32/src/win32.rs
@@ -7,6 +7,7 @@ pub use kernel_builder::Win32KernelBuilder;
 pub use kernel_info::Win32KernelInfo;
 
 pub mod keyboard;
+pub mod vkey;
 pub mod module;
 pub mod process;
 pub mod unicode_string;

--- a/memflow-win32/src/win32/kernel.rs
+++ b/memflow-win32/src/win32/kernel.rs
@@ -142,13 +142,18 @@ impl<T: 'static + PhysicalMemory + Clone, V: 'static + VirtualTranslate2 + Clone
             let pe = PeView::from_bytes(&image).map_err(|err| {
                 Error(ErrorOrigin::OsLayer, ErrorKind::InvalidExeFile).log_info(err)
             })?;
-            let addr = match pe.get_export_by_name(muddy!("PsLoadedModuleList")).map_err(|err| {
-                Error(ErrorOrigin::OsLayer, ErrorKind::ExportNotFound).log_info(err)
-            })? {
+            let addr = match pe
+                .get_export_by_name(muddy!("PsLoadedModuleList"))
+                .map_err(|err| {
+                    Error(ErrorOrigin::OsLayer, ErrorKind::ExportNotFound).log_info(err)
+                })? {
                 Export::Symbol(s) => self.kernel_info.os_info.base + *s as umem,
                 Export::Forward(_) => {
-                    return Err(Error(ErrorOrigin::OsLayer, ErrorKind::ExportNotFound)
-                        .log_info(muddy!("PsLoadedModuleList found but it was a forwarded export")))
+                    return Err(
+                        Error(ErrorOrigin::OsLayer, ErrorKind::ExportNotFound).log_info(muddy!(
+                            "PsLoadedModuleList found but it was a forwarded export"
+                        )),
+                    )
                 }
             };
 

--- a/memflow-win32/src/win32/kernel.rs
+++ b/memflow-win32/src/win32/kernel.rs
@@ -25,6 +25,8 @@ use std::convert::TryInto;
 use std::fmt;
 use std::prelude::v1::*;
 
+use muddy::muddy;
+
 use pelite::{self, pe64::exports::Export, PeView};
 
 const MAX_ITER_COUNT: usize = 65536;
@@ -140,13 +142,13 @@ impl<T: 'static + PhysicalMemory + Clone, V: 'static + VirtualTranslate2 + Clone
             let pe = PeView::from_bytes(&image).map_err(|err| {
                 Error(ErrorOrigin::OsLayer, ErrorKind::InvalidExeFile).log_info(err)
             })?;
-            let addr = match pe.get_export_by_name("PsLoadedModuleList").map_err(|err| {
+            let addr = match pe.get_export_by_name(muddy!("PsLoadedModuleList")).map_err(|err| {
                 Error(ErrorOrigin::OsLayer, ErrorKind::ExportNotFound).log_info(err)
             })? {
                 Export::Symbol(s) => self.kernel_info.os_info.base + *s as umem,
                 Export::Forward(_) => {
                     return Err(Error(ErrorOrigin::OsLayer, ErrorKind::ExportNotFound)
-                        .log_info("PsLoadedModuleList found but it was a forwarded export"))
+                        .log_info(muddy!("PsLoadedModuleList found but it was a forwarded export")))
                 }
             };
 
@@ -179,7 +181,7 @@ impl<T: 'static + PhysicalMemory + Clone, V: 'static + VirtualTranslate2 + Clone
                 address: self.kernel_info.os_info.base,
                 pid: 0,
                 state: ProcessState::Alive,
-                name: "ntoskrnl.exe".into(),
+                name: muddy!("ntoskrnl.exe").into(),
                 path: "".into(),
                 command_line: "".into(),
                 sys_arch: self.kernel_info.os_info.arch,
@@ -648,14 +650,14 @@ impl<T: 'static + PhysicalMemory + Clone, V: 'static + VirtualTranslate2 + Clone
     ///
     /// This will generally be for the initial executable that was run
     fn primary_module_address(&mut self) -> Result<Address> {
-        Ok(self.module_by_name("ntoskrnl.exe")?.address)
+        Ok(self.module_by_name(muddy!("ntoskrnl.exe"))?.address)
     }
 
     /// Retrieves information for the primary module of the process
     ///
     /// This will generally be the initial executable that was run
     fn primary_module(&mut self) -> Result<ModuleInfo> {
-        self.module_by_name("ntoskrnl.exe")
+        self.module_by_name(muddy!("ntoskrnl.exe"))
     }
 
     /// Retrieves a list of all imports of a given module

--- a/memflow-win32/src/win32/keyboard.rs
+++ b/memflow-win32/src/win32/keyboard.rs
@@ -203,7 +203,7 @@ impl<T> Win32Keyboard<T> {
         // let at_least_23_h2 = winver >= (10, 0, 22621).into();
         let at_least_24_h2 = winver >= (10, 0, 22632).into();
         info!(
-            "Loading keyyboard for {} build {}",
+            "Loading keyboard for {} build {}",
             if is_win11 { "Win11" } else { "Win10" },
             winver
         );

--- a/memflow-win32/src/win32/keyboard.rs
+++ b/memflow-win32/src/win32/keyboard.rs
@@ -234,7 +234,7 @@ impl<T> Win32Keyboard<T> {
                 // 48 8B 05 ? ? ? ? FF C9 + 3 -> rel32 deref
                 // or 48 8B 05 ? ? ? ? FF C9 48 8B 04 C8 + 3 -> rel32 deref
 
-                let sig;
+                let sig: &'static str;
                 #[cfg(feature = "regex")]
                 {
                     sig = ida_regex![48 8B 05 ? ? ? ? FF C9];

--- a/memflow-win32/src/win32/keyboard.rs
+++ b/memflow-win32/src/win32/keyboard.rs
@@ -505,7 +505,7 @@ impl<T> Win32Keyboard<T> {
             .data_part()?;
 
         // 48 8B 05 ? ? ? ? 48 89 81 ? ? 00 00 48 8B 8F + 0x3
-        let re = Regex::new(muddy!("(?-u)\\x48\\x8B\\x05(?s:.)(?s:.)(?s:.)(?s:.)\\x48\\x89\\x81(?s:.)(?s:.)\\x00\\x00\\x48\\x8B\\x8F"))
+        let re = Regex::new(ida_regex![48 8B 05 ? ? ? ? 48 89 81 ? ? 00 00 48 8B 8F])
                     .map_err(|_| Error(ErrorOrigin::OsLayer, ErrorKind::Encoding).log_info(muddy!("malformed gafAsyncKeyState signature")))?;
         let buf_offs = re
             .find(module_buf.as_slice())

--- a/memflow-win32/src/win32/keyboard.rs
+++ b/memflow-win32/src/win32/keyboard.rs
@@ -278,9 +278,9 @@ impl<T> Win32Keyboard<T> {
                 Ok(m) => m,
                 Err(_) => {
                     return Err(
-                        Error(ErrorOrigin::OsLayer, ErrorKind::ModuleNotFound).log_info(format_args!(
-                            "unable to find kernel module {target_kernel_module_name}"
-                        )),
+                        Error(ErrorOrigin::OsLayer, ErrorKind::ModuleNotFound).log_info(
+                            ["unable to find kernel module", target_kernel_module_name].join(" ")
+                        ),
                     )
                 }
             };

--- a/memflow-win32/src/win32/keyboard.rs
+++ b/memflow-win32/src/win32/keyboard.rs
@@ -241,8 +241,12 @@ impl<T> Win32Keyboard<T> {
                 }
                 #[cfg(not(feature = "regex"))]
                 {
-                    sig = "48 8B 05 ? ? ? ? FF C9"; // todo: repalce with pelite sig
+                    return Err(
+                        Error(ErrorOrigin::OsLayer, ErrorKind::UnsupportedOptionalFeature)
+                        .log_error("signature scanning requires regex")
+                    ); // todo: repalce with pelite sig
                 }
+                
 
                 (sig, muddy!("win32k.sys"), 0x824F0, 0x3808) // 24H2  win32k.sys + 0x824F0
             } else {
@@ -267,7 +271,10 @@ impl<T> Win32Keyboard<T> {
                 }
                 #[cfg(not(feature = "regex"))]
                 {
-                    sig = "48 8B 05 ? ? ? ? 48 8B 04 C8"; // todo: repalce with pelite sig
+                    return Err(
+                        Error(ErrorOrigin::OsLayer, ErrorKind::UnsupportedOptionalFeature)
+                        .log_error("signature scanning requires regex")
+                    ); // todo: repalce with pelite sig
                 }
 
                 (sig, muddy!("WIN32KSGD.SYS"), 0x3110, 0x36a8) // 0x3690 or 0x36a8 // 23h2 and below win32ksgd.sys + 0x3110

--- a/memflow-win32/src/win32/keyboard.rs
+++ b/memflow-win32/src/win32/keyboard.rs
@@ -43,7 +43,7 @@ use memflow::types::{umem, Address};
 #[cfg(feature = "plugins")]
 use memflow::cglue;
 
-use log::debug;
+use log::{debug, info};
 use std::convert::TryInto;
 
 #[cfg(feature = "plugins")]
@@ -197,9 +197,9 @@ impl<T> Win32Keyboard<T> {
         // Win32k temporary session global driver was first introduced in 22H2 (10.0.22621.1) (2022-09-20)
         // so we cannot be sure it will be active on all Win11 devices
         let winver = kernel.kernel_info.kernel_winver;
-        if winver >= (10, 0, 22621).into() {
-            debug!("Windows 11 detected.");
-
+        let is_win11 = winver >= (10, 0, 22621).into();
+        info!("Loading keyyboard for {} build {}", if is_win11 { "Win11" } else { "Win10" }, winver);
+        if is_win11 {
             // offset from module base of gSessionGlobalSlots in win32k.sys (24h2) or win32ksgd.sys (on 23h2)
             // todo add a signature scan for this and use this behaviour as a fallback
             let (

--- a/memflow-win32/src/win32/keyboard.rs
+++ b/memflow-win32/src/win32/keyboard.rs
@@ -285,20 +285,6 @@ impl<T> Win32Keyboard<T> {
                 }
             };
 
-            // let mut k_module= Err(Error(ErrorOrigin::OsLayer, ErrorKind::ProcessNotFound));
-            // let callback = &mut |data: ModuleInfo| {
-            //     // if data.name.as_ref() == "WIN32KSGD.SYS" || data.name.as_ref() == "WIN32K.SYS" {
-            //     // log::info!("compare module name: {:?}", data.name.as_ref());
-            //     if data.name.as_ref() == target_kernel_module_name {
-            //         k_module = Ok(data);
-            //         false
-            //     } else {
-            //         true
-            //     }
-            // };
-            // kernel.module_list_callback(callback.into())?;
-            // let win32ksgd_module_info = k_module?;
-
             debug!("Found kernel module: {:?}", win32ksgd_module_info);
 
             // find the key states offset:
@@ -368,11 +354,6 @@ impl<T> Win32Keyboard<T> {
                         })
                     })
                     .unwrap_or(g_session_global_slots_offset_fallback);
-                // if res.is_null() {
-                //     g_session_global_slots_address = win32ksgd_module_info.base + g_session_global_slots_offset_fallback
-                // } else {
-                //     g_session_global_slots_address = res;
-                // }
             };
             #[cfg(not(feature = "regex"))]
             {
@@ -451,30 +432,7 @@ impl<T> Win32Keyboard<T> {
         }
     }
 
-    /// Returns offset to what was pointed to by the relative instruction
-    // fn scan_module_sig_rip(module_buf: Vec<u8>, sig: &str, offset_to_rel32: usize) -> Result<umem> {
-    //     use ::regex::bytes::*;
-    //     // 48 8B 05 ? ? ? ? 48 89 81 ? ? 00 00 48 8B 8F + 0x3
-    //     let re = Regex::new(sig)
-    //                 .map_err(|_| Error(ErrorOrigin::OsLayer, ErrorKind::Encoding).log_info(muddy!("malformed rip signature")))?;
-    //     let buf_offs = re
-    //         .find(module_buf.as_slice())
-    //         .ok_or_else(|| {
-    //             Error(ErrorOrigin::OsLayer, ErrorKind::NotFound)
-    //                 .log_info(muddy!("unable to find rip signature"))
-    //         })?
-    //         .start()
-    //         + offset_to_rel32; // this is most often 0x3
-
-    //     // compute rip relative addr
-    //     let export_offs = buf_offs as u32
-    //         + u32::from_le_bytes(module_buf[buf_offs..buf_offs + 4].try_into().unwrap())
-    //         + 0x4;
-
-    //     Ok(export_offs as umem)
-    // }
-
-    // returns the 32bit value in a the function assembly (instead of reading it as a RIP Relative (rel32) Address)
+    /// returns the 32bit value in a the function assembly (instead of reading it as a RIP Relative (rel32) Address)
     #[cfg(feature = "regex")]
     fn scan_module_sig_val32(
         module_buf: Vec<u8>,

--- a/memflow-win32/src/win32/keyboard.rs
+++ b/memflow-win32/src/win32/keyboard.rs
@@ -278,7 +278,7 @@ impl<T> Win32Keyboard<T> {
                 Ok(m) => m,
                 Err(_) => {
                     return Err(
-                        Error(ErrorOrigin::OsLayer, ErrorKind::ModuleNotFound).log_info(format!(
+                        Error(ErrorOrigin::OsLayer, ErrorKind::ModuleNotFound).log_info(format_args!(
                             "unable to find kernel module {target_kernel_module_name}"
                         )),
                     )
@@ -475,6 +475,7 @@ impl<T> Win32Keyboard<T> {
     // }
 
     // returns the 32bit value in a the function assembly (instead of reading it as a RIP Relative (rel32) Address)
+    #[cfg(feature = "regex")]
     fn scan_module_sig_val32(
         module_buf: Vec<u8>,
         sig: &str,

--- a/memflow-win32/src/win32/keyboard.rs
+++ b/memflow-win32/src/win32/keyboard.rs
@@ -243,7 +243,7 @@ impl<T> Win32Keyboard<T> {
                 {
                     return Err(
                         Error(ErrorOrigin::OsLayer, ErrorKind::UnsupportedOptionalFeature)
-                        .log_error("signature scanning requires regex")
+                        .log_error("cannot find keyboard signature because regex feature is disabled")
                     ); // todo: repalce with pelite sig
                 }
                 
@@ -273,7 +273,7 @@ impl<T> Win32Keyboard<T> {
                 {
                     return Err(
                         Error(ErrorOrigin::OsLayer, ErrorKind::UnsupportedOptionalFeature)
-                        .log_error("signature scanning requires regex")
+                        .log_error("cannot find keyboard signature because regex feature is disabled")
                     ); // todo: repalce with pelite sig
                 }
 
@@ -577,7 +577,7 @@ impl<T> Win32Keyboard<T> {
     ) -> Result<umem> {
         Err(
             Error(ErrorOrigin::OsLayer, ErrorKind::UnsupportedOptionalFeature)
-                .log_error("signature scanning requires std"),
+                .log_error("cannot find keyboard signature because regex feature is disabled"),
         )
     }
 
@@ -588,7 +588,7 @@ impl<T> Win32Keyboard<T> {
     ) -> Result<umem> {
         Err(
             Error(ErrorOrigin::OsLayer, ErrorKind::UnsupportedOptionalFeature)
-                .log_error("signature scanning requires std"),
+                .log_error("cannot find keyboard signature because regex feature is disabled"),
         )
     }
 }

--- a/memflow-win32/src/win32/vkey.rs
+++ b/memflow-win32/src/win32/vkey.rs
@@ -3,10 +3,18 @@ use core::ops::{Deref, DerefMut};
 /// Windows Virtual Key Codes
 /// Based on the windows rust api https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/UI/Input/KeyboardAndMouse/
 /// except more flexible and cross platform
-pub const UMLAUT: u32 = 776u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct VKEY(pub u16);
+
+/// auto implement Display based on actual enum name
+/// Utilizes the Debug trait to print the enum name
+/// This works better on enum types.
+impl std::fmt::Display for VKEY {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
 
 impl Deref for VKEY {
     type Target = u16;
@@ -49,6 +57,28 @@ impl From<i32> for VKEY {
 impl From<VKEY> for i32 {
     fn from(vk: VKEY) -> Self {
         vk.0 as i32
+    }
+}
+
+/// Iterate over a range of VKEYs (inclusive start, exclusive end)
+/// Placeholder until we can use the `Step` trait
+/// in a stable way
+pub fn vkey_range(start: VKEY, end: VKEY) -> impl Iterator<Item = VKEY> {
+    (start.0..end.0).map(VKEY)
+}
+
+#[cfg(all(feature = "nightly", nightly))]
+use std::{iter::Step};
+#[cfg(all(feature = "nightly", nightly))]
+impl std::iter::Step for VKEY {
+    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+        u16::steps_between(&start.0, &end.0)
+    }
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        u16::forward_checked(start.0, count).map(VKEY)
+    }
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        u16::backward_checked(start.0, count).map(VKEY)
     }
 }
 

--- a/memflow-win32/src/win32/vkey.rs
+++ b/memflow-win32/src/win32/vkey.rs
@@ -1,0 +1,305 @@
+use core::ops::{Deref, DerefMut};
+
+/// Windows Virtual Key Codes
+/// Based on the windows rust api https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/UI/Input/KeyboardAndMouse/
+/// except more flexible and cross platform
+pub const UMLAUT: u32 = 776u32;
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct VKEY(pub u16);
+
+impl Deref for VKEY {
+    type Target = u16;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl DerefMut for VKEY {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<VKEY> for u16 {
+    fn from(vk: VKEY) -> Self {
+        vk.0
+    }
+}
+impl From<u16> for VKEY {
+    fn from(v: u16) -> Self {
+        VKEY(v)
+    }
+}
+impl From<VKEY> for u32 {
+    fn from(vk: VKEY) -> Self {
+        vk.0 as u32
+    }
+}
+impl From<u32> for VKEY {
+    fn from(v: u32) -> Self {
+        VKEY(v as u16)
+    }
+}
+impl From<i32> for VKEY {
+    fn from(v: i32) -> Self {
+        VKEY(v as u16)
+    }
+}
+impl From<VKEY> for i32 {
+    fn from(vk: VKEY) -> Self {
+        vk.0 as i32
+    }
+}
+
+pub const VK_0: VKEY = VKEY(48u16);
+pub const VK_1: VKEY = VKEY(49u16);
+pub const VK_2: VKEY = VKEY(50u16);
+pub const VK_3: VKEY = VKEY(51u16);
+pub const VK_4: VKEY = VKEY(52u16);
+pub const VK_5: VKEY = VKEY(53u16);
+pub const VK_6: VKEY = VKEY(54u16);
+pub const VK_7: VKEY = VKEY(55u16);
+pub const VK_8: VKEY = VKEY(56u16);
+pub const VK_9: VKEY = VKEY(57u16);
+pub const VK_A: VKEY = VKEY(65u16);
+pub const VK_ABNT_C1: VKEY = VKEY(193u16);
+pub const VK_ABNT_C2: VKEY = VKEY(194u16);
+pub const VK_ACCEPT: VKEY = VKEY(30u16);
+pub const VK_ADD: VKEY = VKEY(107u16);
+pub const VK_APPS: VKEY = VKEY(93u16);
+pub const VK_ATTN: VKEY = VKEY(246u16);
+pub const VK_B: VKEY = VKEY(66u16);
+pub const VK_BACK: VKEY = VKEY(8u16);
+pub const VK_BROWSER_BACK: VKEY = VKEY(166u16);
+pub const VK_BROWSER_FAVORITES: VKEY = VKEY(171u16);
+pub const VK_BROWSER_FORWARD: VKEY = VKEY(167u16);
+pub const VK_BROWSER_HOME: VKEY = VKEY(172u16);
+pub const VK_BROWSER_REFRESH: VKEY = VKEY(168u16);
+pub const VK_BROWSER_SEARCH: VKEY = VKEY(170u16);
+pub const VK_BROWSER_STOP: VKEY = VKEY(169u16);
+pub const VK_C: VKEY = VKEY(67u16);
+pub const VK_CANCEL: VKEY = VKEY(3u16);
+pub const VK_CAPITAL: VKEY = VKEY(20u16);
+pub const VK_CLEAR: VKEY = VKEY(12u16);
+pub const VK_CONTROL: VKEY = VKEY(17u16);
+pub const VK_CONVERT: VKEY = VKEY(28u16);
+pub const VK_CRSEL: VKEY = VKEY(247u16);
+pub const VK_D: VKEY = VKEY(68u16);
+pub const VK_DBE_ALPHANUMERIC: VKEY = VKEY(240u16);
+pub const VK_DBE_CODEINPUT: VKEY = VKEY(250u16);
+pub const VK_DBE_DBCSCHAR: VKEY = VKEY(244u16);
+pub const VK_DBE_DETERMINESTRING: VKEY = VKEY(252u16);
+pub const VK_DBE_ENTERDLGCONVERSIONMODE: VKEY = VKEY(253u16);
+pub const VK_DBE_ENTERIMECONFIGMODE: VKEY = VKEY(248u16);
+pub const VK_DBE_ENTERWORDREGISTERMODE: VKEY = VKEY(247u16);
+pub const VK_DBE_FLUSHSTRING: VKEY = VKEY(249u16);
+pub const VK_DBE_HIRAGANA: VKEY = VKEY(242u16);
+pub const VK_DBE_KATAKANA: VKEY = VKEY(241u16);
+pub const VK_DBE_NOCODEINPUT: VKEY = VKEY(251u16);
+pub const VK_DBE_NOROMAN: VKEY = VKEY(246u16);
+pub const VK_DBE_ROMAN: VKEY = VKEY(245u16);
+pub const VK_DBE_SBCSCHAR: VKEY = VKEY(243u16);
+pub const VK_DECIMAL: VKEY = VKEY(110u16);
+pub const VK_DELETE: VKEY = VKEY(46u16);
+pub const VK_DIVIDE: VKEY = VKEY(111u16);
+pub const VK_DOWN: VKEY = VKEY(40u16);
+pub const VK_E: VKEY = VKEY(69u16);
+pub const VK_END: VKEY = VKEY(35u16);
+pub const VK_EREOF: VKEY = VKEY(249u16);
+pub const VK_ESCAPE: VKEY = VKEY(27u16);
+pub const VK_EXECUTE: VKEY = VKEY(43u16);
+pub const VK_EXSEL: VKEY = VKEY(248u16);
+
+pub const VK_F: VKEY = VKEY(70u16);
+pub const VK_F1: VKEY = VKEY(112u16);
+pub const VK_F10: VKEY = VKEY(121u16);
+pub const VK_F11: VKEY = VKEY(122u16);
+pub const VK_F12: VKEY = VKEY(123u16);
+pub const VK_F13: VKEY = VKEY(124u16);
+pub const VK_F14: VKEY = VKEY(125u16);
+pub const VK_F15: VKEY = VKEY(126u16);
+pub const VK_F16: VKEY = VKEY(127u16);
+pub const VK_F17: VKEY = VKEY(128u16);
+pub const VK_F18: VKEY = VKEY(129u16);
+pub const VK_F19: VKEY = VKEY(130u16);
+pub const VK_F2: VKEY = VKEY(113u16);
+pub const VK_F20: VKEY = VKEY(131u16);
+pub const VK_F21: VKEY = VKEY(132u16);
+pub const VK_F22: VKEY = VKEY(133u16);
+pub const VK_F23: VKEY = VKEY(134u16);
+pub const VK_F24: VKEY = VKEY(135u16);
+pub const VK_F3: VKEY = VKEY(114u16);
+pub const VK_F4: VKEY = VKEY(115u16);
+pub const VK_F5: VKEY = VKEY(116u16);
+pub const VK_F6: VKEY = VKEY(117u16);
+pub const VK_F7: VKEY = VKEY(118u16);
+pub const VK_F8: VKEY = VKEY(119u16);
+pub const VK_F9: VKEY = VKEY(120u16);
+pub const VK_FINAL: VKEY = VKEY(24u16);
+
+pub const VK_G: VKEY = VKEY(71u16);
+pub const VK_GAMEPAD_A: VKEY = VKEY(195u16);
+pub const VK_GAMEPAD_B: VKEY = VKEY(196u16);
+pub const VK_GAMEPAD_DPAD_DOWN: VKEY = VKEY(204u16);
+pub const VK_GAMEPAD_DPAD_LEFT: VKEY = VKEY(205u16);
+pub const VK_GAMEPAD_DPAD_RIGHT: VKEY = VKEY(206u16);
+pub const VK_GAMEPAD_DPAD_UP: VKEY = VKEY(203u16);
+pub const VK_GAMEPAD_LEFT_SHOULDER: VKEY = VKEY(200u16);
+pub const VK_GAMEPAD_LEFT_THUMBSTICK_BUTTON: VKEY = VKEY(209u16);
+pub const VK_GAMEPAD_LEFT_THUMBSTICK_DOWN: VKEY = VKEY(212u16);
+pub const VK_GAMEPAD_LEFT_THUMBSTICK_LEFT: VKEY = VKEY(214u16);
+pub const VK_GAMEPAD_LEFT_THUMBSTICK_RIGHT: VKEY = VKEY(213u16);
+pub const VK_GAMEPAD_LEFT_THUMBSTICK_UP: VKEY = VKEY(211u16);
+pub const VK_GAMEPAD_LEFT_TRIGGER: VKEY = VKEY(201u16);
+pub const VK_GAMEPAD_MENU: VKEY = VKEY(207u16);
+pub const VK_GAMEPAD_RIGHT_SHOULDER: VKEY = VKEY(199u16);
+pub const VK_GAMEPAD_RIGHT_THUMBSTICK_BUTTON: VKEY = VKEY(210u16);
+pub const VK_GAMEPAD_RIGHT_THUMBSTICK_DOWN: VKEY = VKEY(216u16);
+pub const VK_GAMEPAD_RIGHT_THUMBSTICK_LEFT: VKEY = VKEY(218u16);
+pub const VK_GAMEPAD_RIGHT_THUMBSTICK_RIGHT: VKEY = VKEY(217u16);
+pub const VK_GAMEPAD_RIGHT_THUMBSTICK_UP: VKEY = VKEY(215u16);
+pub const VK_GAMEPAD_RIGHT_TRIGGER: VKEY = VKEY(202u16);
+pub const VK_GAMEPAD_VIEW: VKEY = VKEY(208u16);
+pub const VK_GAMEPAD_X: VKEY = VKEY(197u16);
+pub const VK_GAMEPAD_Y: VKEY = VKEY(198u16);
+pub const VK_H: VKEY = VKEY(72u16);
+pub const VK_HANGEUL: VKEY = VKEY(21u16);
+pub const VK_HANGUL: VKEY = VKEY(21u16);
+pub const VK_HANJA: VKEY = VKEY(25u16);
+pub const VK_HELP: VKEY = VKEY(47u16);
+pub const VK_HOME: VKEY = VKEY(36u16);
+pub const VK_I: VKEY = VKEY(73u16);
+pub const VK_ICO_00: VKEY = VKEY(228u16);
+pub const VK_ICO_CLEAR: VKEY = VKEY(230u16);
+pub const VK_ICO_HELP: VKEY = VKEY(227u16);
+pub const VK_IME_OFF: VKEY = VKEY(26u16);
+pub const VK_IME_ON: VKEY = VKEY(22u16);
+pub const VK_INSERT: VKEY = VKEY(45u16);
+pub const VK_J: VKEY = VKEY(74u16);
+pub const VK_JUNJA: VKEY = VKEY(23u16);
+pub const VK_K: VKEY = VKEY(75u16);
+pub const VK_KANA: VKEY = VKEY(21u16);
+pub const VK_KANJI: VKEY = VKEY(25u16);
+pub const VK_L: VKEY = VKEY(76u16);
+pub const VK_LAUNCH_APP1: VKEY = VKEY(182u16);
+pub const VK_LAUNCH_APP2: VKEY = VKEY(183u16);
+pub const VK_LAUNCH_MAIL: VKEY = VKEY(180u16);
+pub const VK_LAUNCH_MEDIA_SELECT: VKEY = VKEY(181u16);
+pub const VK_LBUTTON: VKEY = VKEY(1u16);
+pub const VK_LCONTROL: VKEY = VKEY(162u16);
+pub const VK_LEFT: VKEY = VKEY(37u16);
+pub const VK_LMENU: VKEY = VKEY(164u16);
+pub const VK_LSHIFT: VKEY = VKEY(160u16);
+pub const VK_LWIN: VKEY = VKEY(91u16);
+pub const VK_M: VKEY = VKEY(77u16);
+pub const VK_MBUTTON: VKEY = VKEY(4u16);
+pub const VK_MEDIA_NEXT_TRACK: VKEY = VKEY(176u16);
+pub const VK_MEDIA_PLAY_PAUSE: VKEY = VKEY(179u16);
+pub const VK_MEDIA_PREV_TRACK: VKEY = VKEY(177u16);
+pub const VK_MEDIA_STOP: VKEY = VKEY(178u16);
+pub const VK_MENU: VKEY = VKEY(18u16);
+pub const VK_MODECHANGE: VKEY = VKEY(31u16);
+pub const VK_MULTIPLY: VKEY = VKEY(106u16);
+pub const VK_N: VKEY = VKEY(78u16);
+pub const VK_NAVIGATION_ACCEPT: VKEY = VKEY(142u16);
+pub const VK_NAVIGATION_CANCEL: VKEY = VKEY(143u16);
+pub const VK_NAVIGATION_DOWN: VKEY = VKEY(139u16);
+pub const VK_NAVIGATION_LEFT: VKEY = VKEY(140u16);
+pub const VK_NAVIGATION_MENU: VKEY = VKEY(137u16);
+pub const VK_NAVIGATION_RIGHT: VKEY = VKEY(141u16);
+pub const VK_NAVIGATION_UP: VKEY = VKEY(138u16);
+pub const VK_NAVIGATION_VIEW: VKEY = VKEY(136u16);
+pub const VK_NEXT: VKEY = VKEY(34u16);
+pub const VK_NONAME: VKEY = VKEY(252u16);
+pub const VK_NONCONVERT: VKEY = VKEY(29u16);
+pub const VK_NUMLOCK: VKEY = VKEY(144u16);
+pub const VK_NUMPAD0: VKEY = VKEY(96u16);
+pub const VK_NUMPAD1: VKEY = VKEY(97u16);
+pub const VK_NUMPAD2: VKEY = VKEY(98u16);
+pub const VK_NUMPAD3: VKEY = VKEY(99u16);
+pub const VK_NUMPAD4: VKEY = VKEY(100u16);
+pub const VK_NUMPAD5: VKEY = VKEY(101u16);
+pub const VK_NUMPAD6: VKEY = VKEY(102u16);
+pub const VK_NUMPAD7: VKEY = VKEY(103u16);
+pub const VK_NUMPAD8: VKEY = VKEY(104u16);
+pub const VK_NUMPAD9: VKEY = VKEY(105u16);
+pub const VK_O: VKEY = VKEY(79u16);
+pub const VK_OEM_1: VKEY = VKEY(186u16);
+pub const VK_OEM_102: VKEY = VKEY(226u16);
+pub const VK_OEM_2: VKEY = VKEY(191u16);
+pub const VK_OEM_3: VKEY = VKEY(192u16);
+pub const VK_OEM_4: VKEY = VKEY(219u16);
+pub const VK_OEM_5: VKEY = VKEY(220u16);
+pub const VK_OEM_6: VKEY = VKEY(221u16);
+pub const VK_OEM_7: VKEY = VKEY(222u16);
+pub const VK_OEM_8: VKEY = VKEY(223u16);
+pub const VK_OEM_ATTN: VKEY = VKEY(240u16);
+pub const VK_OEM_AUTO: VKEY = VKEY(243u16);
+pub const VK_OEM_AX: VKEY = VKEY(225u16);
+pub const VK_OEM_BACKTAB: VKEY = VKEY(245u16);
+pub const VK_OEM_CLEAR: VKEY = VKEY(254u16);
+pub const VK_OEM_COMMA: VKEY = VKEY(188u16);
+pub const VK_OEM_COPY: VKEY = VKEY(242u16);
+pub const VK_OEM_CUSEL: VKEY = VKEY(239u16);
+pub const VK_OEM_ENLW: VKEY = VKEY(244u16);
+pub const VK_OEM_FINISH: VKEY = VKEY(241u16);
+pub const VK_OEM_FJ_JISHO: VKEY = VKEY(146u16);
+pub const VK_OEM_FJ_LOYA: VKEY = VKEY(149u16);
+pub const VK_OEM_FJ_MASSHOU: VKEY = VKEY(147u16);
+pub const VK_OEM_FJ_ROYA: VKEY = VKEY(150u16);
+pub const VK_OEM_FJ_TOUROKU: VKEY = VKEY(148u16);
+pub const VK_OEM_JUMP: VKEY = VKEY(234u16);
+pub const VK_OEM_MINUS: VKEY = VKEY(189u16);
+pub const VK_OEM_NEC_EQUAL: VKEY = VKEY(146u16);
+pub const VK_OEM_PA1: VKEY = VKEY(235u16);
+pub const VK_OEM_PA2: VKEY = VKEY(236u16);
+pub const VK_OEM_PA3: VKEY = VKEY(237u16);
+pub const VK_OEM_PERIOD: VKEY = VKEY(190u16);
+pub const VK_OEM_PLUS: VKEY = VKEY(187u16);
+pub const VK_OEM_RESET: VKEY = VKEY(233u16);
+pub const VK_OEM_WSCTRL: VKEY = VKEY(238u16);
+pub const VK_P: VKEY = VKEY(80u16);
+pub const VK_PA1: VKEY = VKEY(253u16);
+pub const VK_PACKET: VKEY = VKEY(231u16);
+pub const VK_PAUSE: VKEY = VKEY(19u16);
+pub const VK_PLAY: VKEY = VKEY(250u16);
+pub const VK_PRINT: VKEY = VKEY(42u16);
+pub const VK_PRIOR: VKEY = VKEY(33u16);
+pub const VK_PROCESSKEY: VKEY = VKEY(229u16);
+pub const VK_Q: VKEY = VKEY(81u16);
+pub const VK_R: VKEY = VKEY(82u16);
+pub const VK_RBUTTON: VKEY = VKEY(2u16);
+pub const VK_RCONTROL: VKEY = VKEY(163u16);
+pub const VK_RETURN: VKEY = VKEY(13u16);
+pub const VK_RIGHT: VKEY = VKEY(39u16);
+pub const VK_RMENU: VKEY = VKEY(165u16);
+pub const VK_RSHIFT: VKEY = VKEY(161u16);
+pub const VK_RWIN: VKEY = VKEY(92u16);
+pub const VK_S: VKEY = VKEY(83u16);
+pub const VK_SCROLL: VKEY = VKEY(145u16);
+pub const VK_SELECT: VKEY = VKEY(41u16);
+pub const VK_SEPARATOR: VKEY = VKEY(108u16);
+pub const VK_SHIFT: VKEY = VKEY(16u16);
+pub const VK_SLEEP: VKEY = VKEY(95u16);
+pub const VK_SNAPSHOT: VKEY = VKEY(44u16);
+pub const VK_SPACE: VKEY = VKEY(32u16);
+pub const VK_SUBTRACT: VKEY = VKEY(109u16);
+pub const VK_T: VKEY = VKEY(84u16);
+pub const VK_TAB: VKEY = VKEY(9u16);
+
+pub const VK_U: VKEY = VKEY(85u16);
+pub const VK_UP: VKEY = VKEY(38u16);
+pub const VK_V: VKEY = VKEY(86u16);
+pub const VK_VOLUME_DOWN: VKEY = VKEY(174u16);
+pub const VK_VOLUME_MUTE: VKEY = VKEY(173u16);
+pub const VK_VOLUME_UP: VKEY = VKEY(175u16);
+
+pub const VK_W: VKEY = VKEY(87u16);
+pub const VK_X: VKEY = VKEY(88u16);
+pub const VK_XBUTTON1: VKEY = VKEY(5u16);
+pub const VK_XBUTTON2: VKEY = VKEY(6u16);
+pub const VK_Y: VKEY = VKEY(89u16);
+pub const VK_Z: VKEY = VKEY(90u16);
+pub const VK_ZOOM: VKEY = VKEY(251u16);
+pub const VK__none_: VKEY = VKEY(255u16);

--- a/memflow-win32/src/win32/vkey.rs
+++ b/memflow-win32/src/win32/vkey.rs
@@ -302,4 +302,4 @@ pub const VK_XBUTTON2: VKEY = VKEY(6u16);
 pub const VK_Y: VKEY = VKEY(89u16);
 pub const VK_Z: VKEY = VKEY(90u16);
 pub const VK_ZOOM: VKEY = VKEY(251u16);
-pub const VK__none_: VKEY = VKEY(255u16);
+pub const VK_NONE: VKEY = VKEY(255u16);


### PR DESCRIPTION
The handling of getting key states for Windows 11 versions 23H2 and 24H2 has been extended to utilize signatures instead of hardcoded offsets, in addition to a version barrier check to handle the changeover in which module key states are defined in. This should resolve #11 and #5. In addition, it should be generally more robust now against updates since I handmade the signatures with comparisons across several windows versions of the modules in question.

Another little bonus added: there is now a keyboard reader / tester in the examples folder.